### PR TITLE
patch devise to work with rails 8 routes

### DIFF
--- a/config/initializers/devise_rails8_patch.rb
+++ b/config/initializers/devise_rails8_patch.rb
@@ -1,5 +1,6 @@
-require 'devise'
-Devise # make sure it's already loaded
+# frozen_string_literal: true
+
+require 'devise' # make sure it's already loaded
 
 module Devise
   def self.mappings

--- a/config/initializers/devise_rails8_patch.rb
+++ b/config/initializers/devise_rails8_patch.rb
@@ -1,0 +1,12 @@
+require 'devise'
+Devise # make sure it's already loaded
+
+module Devise
+  def self.mappings
+    # Starting from Rails 8.0, routes are lazy-loaded by default in test and development environments.
+    # However, Devise's mappings are built during the routes loading phase.
+    # To ensure it works correctly, we need to load the routes first before accessing @@mappings.
+    Rails.application.try(:reload_routes_unless_loaded)
+    @@mappings
+  end
+end


### PR DESCRIPTION
Devise in rails 8 has an issue with lazy loading routes, and prevents the use of  `sign_in user`

more info look at devise/pull/5728